### PR TITLE
Add ISOSUB and VTEXT layer definitions to klayout

### DIFF
--- a/tech/klayout/gf180mcu.lyp
+++ b/tech/klayout/gf180mcu.lyp
@@ -220,6 +220,23 @@ limitations under the License.
   <source>COMP 22/0@1</source>
  </properties>
  <properties>
+  <frame-color>#ffa080</frame-color>
+  <fill-color>#ffa080</fill-color>
+  <frame-brightness>0</frame-brightness>
+  <fill-brightness>0</fill-brightness>
+  <dither-pattern>I9</dither-pattern>
+  <line-style/>
+  <valid>true</valid>
+  <visible>true</visible>
+  <transparent>false</transparent>
+  <width>1</width>
+  <marked>false</marked>
+  <xfill>false</xfill>
+  <animation>0</animation>
+  <name/>
+  <source>ISOSUB 23/5@1</source>
+ </properties>
+ <properties>
   <frame-color>#88cb1d</frame-color>
   <fill-color>#88cb1d</fill-color>
   <frame-brightness>0</frame-brightness>
@@ -1867,6 +1884,23 @@ limitations under the License.
   <animation>0</animation>
   <name/>
   <source>PR_bndry 0/0@1</source>
+ </properties>
+ <properties>
+  <frame-color>#d9f817</frame-color>
+  <fill-color>#d9f817</fill-color>
+  <frame-brightness>0</frame-brightness>
+  <fill-brightness>0</fill-brightness>
+  <dither-pattern>I9</dither-pattern>
+  <line-style/>
+  <valid>true</valid>
+  <visible>true</visible>
+  <transparent>false</transparent>
+  <width>1</width>
+  <marked>false</marked>
+  <xfill>false</xfill>
+  <animation>0</animation>
+  <name/>
+  <source>VTEXT 63/63@1</source>
  </properties>
  <properties>
   <frame-color>#0bdfb7</frame-color>


### PR DESCRIPTION
These layers are used in the gf180mcu_fd_io cells, but are missing from klayout. 
I've used the names present in the magic definition file, and kept the default colors generated by klayout.