### PR TITLE
CI: run apt update before install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ DRC-PV:
 	@rm -rf globalfoundries-pdk-libs-gf180mcu_fd_pv/ && git clone https://github.com/efabless/globalfoundries-pdk-libs-gf180mcu_fd_pv.git
 	@pip install --break-system-packages -r requirements.txt
 	@wget https://www.klayout.org/downloads/Ubuntu-24/klayout_0.30.2-1_amd64.deb
+	@sudo apt update
 	@sudo apt install -f ./klayout_0.30.2-1_amd64.deb
 
 NG_ENV:


### PR DESCRIPTION
Prevents:

    E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_25.0.7-0ubuntu0.24.04.2_amd64.deb  404  Not Found [IP: 20.106.104.242 80]