### PR TITLE
klayout drc: stop using run_drc.py ground work for parall DRC

### DIFF
--- a/rules/klayout/macros/gf180mcu_drc.lydrc
+++ b/rules/klayout/macros/gf180mcu_drc.lydrc
@@ -48,38 +48,10 @@ end
 ## reading the parent directory of the current file
 run_dir = File.expand_path("..", dir_path)
 
-## read the log of drc run to get output lydb file paths if run_dir option is disables
-gds_name = layout_path.split()[1].to_s.split(".")[0]
-
-out_dir = "#{run_dir}/macros/run_drc_main"
-
-if Dir.exist?out_dir
-  `rm #{out_dir}/drc_run*.log`
-end
-
 if options["top_cell_name"] == ""
   current_cell_name = RBA::CellView.active.cell.name
   options["top_cell_name"] = current_cell_name
 end
-
-## create options passed to run_drc.py
-options_str = "--variant=#{options["variant"]} --run_dir=#{run_dir}/macros/run_drc_main --macro_gen --topcell=#{options["top_cell_name"]}"
-
-## run_drc command line
-cmd = "python3 #{run_dir}/drc/run_drc.py --path=#{layout_path} #{options_str}"
-
-## start running drc
-puts "######### running #{cmd}"
-`#{cmd}`
-status = $?
-
-if status.exitstatus != 0
-  STDERR.puts "Error: run_drc script generation failed with exit code #{status.exitstatus}"
-  exit status.exitstatus
-end
-
-## pass options to main.drc
-$run_mode = options["run_mode"]
 
 if options["variant"] == "A"
   $metal_top = "30K"
@@ -99,32 +71,25 @@ elsif options["variant"] == "D"
   $mim_option = "B"
 end
 
-$topcell = options["top_cell_name"]
+$input=layout_path
+$mim_option=$mim_option
+$metal_top=$metal_top
+$metal_level=$metal_level
+$feol=options["feol"]
+$beol=options["beol"]
+$offgrid=options["offgrid"]
+$run_mode=options["run_mode"]
+$conn_drc=options["connectivity"]
+$verbose=options["verbose"]
+$topcell=options["top_cell_name"]
 
-$verbose = options["verbose"]
-
-$feol = options["feol"]
-
-$beol = options["beol"]
-
-$offgrid = options["offgrid"]
-
-$conn_drc = options["connectivity"]
-
-unless File.exist?"#{run_dir}/macros/run_drc_main/main.drc"
-  STDERR.puts "file run_drc_main.drc doesn't exist"
-  exit
-end
-
-## include run files
+## start running drc
 
 $report = "antenna.lyrdb"
 #%include ../drc/rule_decks/antenna.drc
 $report = "density.lyrdb"
 #%include ../drc/rule_decks/density.drc
 $report = "main.lyrdb"
-#%include run_drc_main/main.drc
-
-
+#%include ../drc/gf180mcu.drc
 </text>
 </klayout-macro>


### PR DESCRIPTION
Introduce gf180mcu.drc as the new entry point for running DRC. 
Code in the GUI launcher was simplified as well, dropping the usage of `run_drc.py`.