### PR TITLE
Improve klayout layer properties file

### DIFF
--- a/tech/klayout/gf180mcu.lyp
+++ b/tech/klayout/gf180mcu.lyp
@@ -16,29 +16,11 @@ limitations under the License.
 -->
 <layer-properties>
  <properties>
-  <frame-color>#55ce57</frame-color>
-  <fill-color>#55ce57</fill-color>
-  <frame-brightness>0</frame-brightness>
-  <fill-brightness>0</fill-brightness>
-  <dither-pattern>I3</dither-pattern>
-  <line-style/>
-  <valid>true</valid>
-  <visible>false</visible>
-  <transparent>false</transparent>
-  <width>1</width>
-  <marked>false</marked>
-  <xfill>false</xfill>
-  <animation>0</animation>
-  <name/>
-  <source>1/222@1</source>
- </properties>
- <properties>
   <frame-color>#661a48</frame-color>
   <fill-color>#661a48</fill-color>
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I3</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -46,8 +28,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>pass_mk 2/222@1</source>
+  <name>pass_mk</name>
+  <source>2/222@1</source>
  </properties>
  <properties>
   <frame-color>#7c6078</frame-color>
@@ -55,7 +37,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I3</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -63,8 +44,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>fail_mk 3/222@1</source>
+  <name>fail_mk</name>
+  <source>3/222</source>
  </properties>
  <properties>
   <frame-color>#f26f6c</frame-color>
@@ -72,7 +53,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I3</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -80,25 +60,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>polygon_mk 4/222@1</source>
- </properties>
- <properties>
-  <frame-color>#324416</frame-color>
-  <fill-color>#324416</fill-color>
-  <frame-brightness>0</frame-brightness>
-  <fill-brightness>0</fill-brightness>
-  <dither-pattern>I3</dither-pattern>
-  <line-style/>
-  <valid>true</valid>
-  <visible>false</visible>
-  <transparent>false</transparent>
-  <width>1</width>
-  <marked>false</marked>
-  <xfill>false</xfill>
-  <animation>0</animation>
-  <name/>
-  <source>5/222@1</source>
+  <name>polygon_mk</name>
+  <source>4/222</source>
  </properties>
  <properties>
   <frame-color>#3acb88</frame-color>
@@ -106,7 +69,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I3</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -114,8 +76,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>violation_mk 6/222@1</source>
+  <name>violation_mk</name>
+  <source>6/222</source>
  </properties>
  <properties>
   <frame-color>#5a68c2</frame-color>
@@ -123,7 +85,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I3</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -131,25 +92,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>rule_txt_mk 11/222@1</source>
- </properties>
- <properties>
-  <frame-color>#718e2d</frame-color>
-  <fill-color>#718e2d</fill-color>
-  <frame-brightness>0</frame-brightness>
-  <fill-brightness>0</fill-brightness>
-  <dither-pattern>I3</dither-pattern>
-  <line-style/>
-  <valid>true</valid>
-  <visible>false</visible>
-  <transparent>false</transparent>
-  <width>1</width>
-  <marked>false</marked>
-  <xfill>false</xfill>
-  <animation>0</animation>
-  <name/>
-  <source>12/222@1</source>
+  <name>rule_txt_mk</name>
+  <source>11/222</source>
  </properties>
  <properties>
   <frame-color>#3f3f3c</frame-color>
@@ -157,7 +101,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I3</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -165,42 +108,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>case_txt_mk 13/222@1</source>
- </properties>
- <properties>
-  <frame-color>#3f12e4</frame-color>
-  <fill-color>#3f12e4</fill-color>
-  <frame-brightness>0</frame-brightness>
-  <fill-brightness>0</fill-brightness>
-  <dither-pattern>I3</dither-pattern>
-  <line-style/>
-  <valid>true</valid>
-  <visible>false</visible>
-  <transparent>false</transparent>
-  <width>1</width>
-  <marked>false</marked>
-  <xfill>false</xfill>
-  <animation>0</animation>
-  <name/>
-  <source>14/222@1</source>
- </properties>
- <properties>
-  <frame-color>#f9bd46</frame-color>
-  <fill-color>#f9bd46</fill-color>
-  <frame-brightness>0</frame-brightness>
-  <fill-brightness>0</fill-brightness>
-  <dither-pattern>I3</dither-pattern>
-  <line-style/>
-  <valid>true</valid>
-  <visible>false</visible>
-  <transparent>false</transparent>
-  <width>1</width>
-  <marked>false</marked>
-  <xfill>false</xfill>
-  <animation>0</animation>
-  <name/>
-  <source>15/222@1</source>
+  <name>case_txt_mk</name>
+  <source>13/222</source>
  </properties>
  <properties>
   <frame-color>#bd74bd</frame-color>
@@ -208,7 +117,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -216,8 +124,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>COMP 22/0@1</source>
+  <name>COMP</name>
+  <source>22/0</source>
  </properties>
  <properties>
   <frame-color>#ffa080</frame-color>
@@ -225,7 +133,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -233,8 +140,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>ISOSUB 23/5@1</source>
+  <name>ISOSUB</name>
+  <source>23/5</source>
  </properties>
  <properties>
   <frame-color>#88cb1d</frame-color>
@@ -242,7 +149,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -250,8 +156,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>DNWELL 12/0@1</source>
+  <name>DNWELL</name>
+  <source>12/0</source>
  </properties>
  <properties>
   <frame-color>#f9946b</frame-color>
@@ -259,7 +165,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -267,8 +172,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Nwell 21/0@1</source>
+  <name>Nwell</name>
+  <source>21/0</source>
  </properties>
  <properties>
   <frame-color>#3a2888</frame-color>
@@ -276,7 +181,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -284,8 +188,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LVPWELL 204/0@1</source>
+  <name>LVPWELL</name>
+  <source>204/0</source>
  </properties>
  <properties>
   <frame-color>#c16f5c</frame-color>
@@ -293,7 +197,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -301,8 +204,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Dualgate 55/0@1</source>
+  <name>Dualgate</name>
+  <source>55/0</source>
  </properties>
  <properties>
   <frame-color>#2e9521</frame-color>
@@ -310,7 +213,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -318,8 +220,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Poly2 30/0@1</source>
+  <name>Poly2</name>
+  <source>30/0</source>
  </properties>
  <properties>
   <frame-color>#bf3efb</frame-color>
@@ -327,7 +229,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -335,8 +236,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Nplus 32/0@1</source>
+  <name>Nplus</name>
+  <source>32/0</source>
  </properties>
  <properties>
   <frame-color>#34c590</frame-color>
@@ -344,7 +245,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -352,8 +252,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Pplus 31/0@1</source>
+  <name>Pplus</name>
+  <source>31/0</source>
  </properties>
  <properties>
   <frame-color>#67392f</frame-color>
@@ -361,7 +261,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -369,8 +268,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>SAB 49/0@1</source>
+  <name>SAB</name>
+  <source>49/0</source>
  </properties>
  <properties>
   <frame-color>#d9ef03</frame-color>
@@ -378,7 +277,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -386,8 +284,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>ESD 24/0@1</source>
+  <name>ESD</name>
+  <source>24/0</source>
  </properties>
  <properties>
   <frame-color>#c86634</frame-color>
@@ -395,7 +293,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -403,8 +300,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Contact 33/0@1</source>
+  <name>Contact</name>
+  <source>33/0</source>
  </properties>
  <properties>
   <frame-color>#eddd07</frame-color>
@@ -412,7 +309,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -420,8 +316,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal1 34/0@1</source>
+  <name>Metal1</name>
+  <source>34/0</source>
  </properties>
  <properties>
   <frame-color>#f5e7f1</frame-color>
@@ -429,7 +325,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -437,8 +332,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Via1 35/0@1</source>
+  <name>Via1</name>
+  <source>35/0</source>
  </properties>
  <properties>
   <frame-color>#ccf338</frame-color>
@@ -446,7 +341,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -454,8 +348,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal2 36/0@1</source>
+  <name>Metal2</name>
+  <source>36/0</source>
  </properties>
  <properties>
   <frame-color>#e1d8ca</frame-color>
@@ -463,7 +357,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -471,8 +364,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Via2 38/0@1</source>
+  <name>Via2</name>
+  <source>38/0</source>
  </properties>
  <properties>
   <frame-color>#97b91b</frame-color>
@@ -480,7 +373,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -488,8 +380,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal3 42/0@1</source>
+  <name>Metal3</name>
+  <source>42/0</source>
  </properties>
  <properties>
   <frame-color>#53e2e8</frame-color>
@@ -497,7 +389,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -505,8 +396,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Via3 40/0@1</source>
+  <name>Via3</name>
+  <source>40/0</source>
  </properties>
  <properties>
   <frame-color>#80317c</frame-color>
@@ -514,7 +405,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -522,8 +412,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal4 46/0@1</source>
+  <name>Metal4</name>
+  <source>46/0</source>
  </properties>
  <properties>
   <frame-color>#a7b1d1</frame-color>
@@ -531,7 +421,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -539,8 +428,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Via4 41/0@1</source>
+  <name>Via4</name>
+  <source>41/0</source>
  </properties>
  <properties>
   <frame-color>#cdc16b</frame-color>
@@ -548,7 +437,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -556,8 +444,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal5 81/0@1</source>
+  <name>Metal5</name>
+  <source>81/0</source>
  </properties>
  <properties>
   <frame-color>#827e5b</frame-color>
@@ -565,7 +453,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -573,8 +460,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Via5 82/0@1</source>
+  <name>Via5</name>
+  <source>82/0</source>
  </properties>
  <properties>
   <frame-color>#b1dd9c</frame-color>
@@ -582,7 +469,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -590,8 +476,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MetalTop 53/0@1</source>
+  <name>MetalTop</name>
+  <source>53/0</source>
  </properties>
  <properties>
   <frame-color>#72342b</frame-color>
@@ -599,7 +485,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -607,8 +492,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Pad 37/0@1</source>
+  <name>Pad</name>
+  <source>37/0</source>
  </properties>
  <properties>
   <frame-color>#1437ff</frame-color>
@@ -616,7 +501,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -624,8 +508,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Resistor 62/0@1</source>
+  <name>Resistor</name>
+  <source>62/0</source>
  </properties>
  <properties>
   <frame-color>#82b18c</frame-color>
@@ -633,7 +517,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -641,8 +524,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>FHRES 227/0@1</source>
+  <name>FHRES</name>
+  <source>227/0</source>
  </properties>
  <properties>
   <frame-color>#b9a4fd</frame-color>
@@ -650,7 +533,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -658,8 +540,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>FuseTop 75/0@1</source>
+  <name>FuseTop</name>
+  <source>75/0</source>
  </properties>
  <properties>
   <frame-color>#87ad41</frame-color>
@@ -667,7 +549,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -675,8 +556,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>FuseWindow_D 96/1@1</source>
+  <name>FuseWindow_D</name>
+  <source>96/1</source>
  </properties>
  <properties>
   <frame-color>#ec7ceb</frame-color>
@@ -684,7 +565,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -692,8 +572,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>POLYFUSE 220/0@1</source>
+  <name>POLYFUSE</name>
+  <source>220/0</source>
  </properties>
  <properties>
   <frame-color>#e29901</frame-color>
@@ -701,7 +581,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -709,8 +588,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MVSD 210/0@1</source>
+  <name>MVSD</name>
+  <source>210/0</source>
  </properties>
  <properties>
   <frame-color>#63a2db</frame-color>
@@ -718,7 +597,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -726,8 +604,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MVPSD 11/39@1</source>
+  <name>MVPSD</name>
+  <source>11/39</source>
  </properties>
  <properties>
   <frame-color>#91d339</frame-color>
@@ -735,7 +613,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -743,8 +620,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>NAT 5/0@1</source>
+  <name>NAT</name>
+  <source>5/0</source>
  </properties>
  <properties>
   <frame-color>#f84e38</frame-color>
@@ -752,7 +629,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -760,8 +636,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>COMP_Dummy 22/4@1</source>
+  <name>COMP_Dummy</name>
+  <source>22/4</source>
  </properties>
  <properties>
   <frame-color>#2d4da8</frame-color>
@@ -769,7 +645,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -777,8 +652,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Poly2_Dummy 30/4@1</source>
+  <name>Poly2_Dummy</name>
+  <source>30/4</source>
  </properties>
  <properties>
   <frame-color>#c01202</frame-color>
@@ -786,7 +661,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -794,8 +668,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal1_Dummy 34/4@1</source>
+  <name>Metal1_Dummy</name>
+  <source>34/4</source>
  </properties>
  <properties>
   <frame-color>#2f93c0</frame-color>
@@ -803,7 +677,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -811,8 +684,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal2_Dummy 36/4@1</source>
+  <name>Metal2_Dummy</name>
+  <source>36/4</source>
  </properties>
  <properties>
   <frame-color>#867300</frame-color>
@@ -820,7 +693,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -828,8 +700,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal3_Dummy 42/4@1</source>
+  <name>Metal3_Dummy</name>
+  <source>42/4</source>
  </properties>
  <properties>
   <frame-color>#e86c70</frame-color>
@@ -837,7 +709,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -845,8 +716,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal4_Dummy 46/4@1</source>
+  <name>Metal4_Dummy</name>
+  <source>46/4</source>
  </properties>
  <properties>
   <frame-color>#26676b</frame-color>
@@ -854,7 +725,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -862,8 +732,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal5_Dummy 81/4@1</source>
+  <name>Metal5_Dummy</name>
+  <source>81/4</source>
  </properties>
  <properties>
   <frame-color>#60fe08</frame-color>
@@ -871,7 +741,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -879,8 +748,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MetalTop_Dummy 53/4@1</source>
+  <name>MetalTop_Dummy</name>
+  <source>53/4</source>
  </properties>
  <properties>
   <frame-color>#4665c7</frame-color>
@@ -888,7 +757,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -896,8 +764,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>COMP_Label 22/10@1</source>
+  <name>COMP_Label</name>
+  <source>22/10</source>
  </properties>
  <properties>
   <frame-color>#fb1879</frame-color>
@@ -905,7 +773,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -913,8 +780,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Poly2_Label 30/10@1</source>
+  <name>Poly2_Label</name>
+  <source>30/10</source>
  </properties>
  <properties>
   <frame-color>#880f5b</frame-color>
@@ -922,7 +789,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -930,8 +796,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal1_Label 34/10@1</source>
+  <name>Metal1_Label</name>
+  <source>34/10</source>
  </properties>
  <properties>
   <frame-color>#ff80b7</frame-color>
@@ -939,7 +805,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -947,8 +812,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal2_Label 36/10@1</source>
+  <name>Metal2_Label</name>
+  <source>36/10</source>
  </properties>
  <properties>
   <frame-color>#ad9348</frame-color>
@@ -956,7 +821,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -964,8 +828,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal3_Label 42/10@1</source>
+  <name>Metal3_Label</name>
+  <source>42/10</source>
  </properties>
  <properties>
   <frame-color>#876bbe</frame-color>
@@ -973,7 +837,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -981,8 +844,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal4_Label 46/10@1</source>
+  <name>Metal4_Label</name>
+  <source>46/10</source>
  </properties>
  <properties>
   <frame-color>#43e12f</frame-color>
@@ -990,7 +853,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>false</visible>
   <transparent>false</transparent>
@@ -998,8 +860,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal5_Label 81/10@1</source>
+  <name>Metal5_Label</name>
+  <source>81/10</source>
  </properties>
  <properties>
   <frame-color>#a6ec0e</frame-color>
@@ -1007,7 +869,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1015,8 +876,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MetalTop_Label 53/10@1</source>
+  <name>MetalTop_Label</name>
+  <source>53/10</source>
  </properties>
  <properties>
   <frame-color>#271fe3</frame-color>
@@ -1024,7 +885,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1032,8 +892,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal1_Slot 34/3@1</source>
+  <name>Metal1_Slot</name>
+  <source>34/3</source>
  </properties>
  <properties>
   <frame-color>#d56ff8</frame-color>
@@ -1041,7 +901,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1049,8 +908,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal2_Slot 36/3@1</source>
+  <name>Metal2_Slot</name>
+  <source>36/3</source>
  </properties>
  <properties>
   <frame-color>#d8c178</frame-color>
@@ -1058,7 +917,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1066,8 +924,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal3_Slot 42/3@1</source>
+  <name>Metal3_Slot</name>
+  <source>42/3</source>
  </properties>
  <properties>
   <frame-color>#6c36fb</frame-color>
@@ -1075,7 +933,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1083,8 +940,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal4_Slot 46/3@1</source>
+  <name>Metal4_Slot</name>
+  <source>46/3</source>
  </properties>
  <properties>
   <frame-color>#225c09</frame-color>
@@ -1092,7 +949,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1100,8 +956,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal5_Slot 81/3@1</source>
+  <name>Metal5_Slot</name>
+  <source>81/3</source>
  </properties>
  <properties>
   <frame-color>#03f979</frame-color>
@@ -1109,7 +965,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1117,8 +972,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MetalTop_Slot 53/3@1</source>
+  <name>MetalTop_Slot</name>
+  <source>53/3</source>
  </properties>
  <properties>
   <frame-color>#6c9be2</frame-color>
@@ -1126,7 +981,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1134,8 +988,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>UBMPPeri 183/0@1</source>
+  <name>UBMPPeri</name>
+  <source>183/0</source>
  </properties>
  <properties>
   <frame-color>#0174b8</frame-color>
@@ -1143,7 +997,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1151,8 +1004,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>UBMPArray 184/0@1</source>
+  <name>UBMPArray</name>
+  <source>184/0</source>
  </properties>
  <properties>
   <frame-color>#5bdc70</frame-color>
@@ -1160,7 +1013,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1168,8 +1020,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>UBMEPlate 185/0@1</source>
+  <name>UBMEPlate</name>
+  <source>185/0</source>
  </properties>
  <properties>
   <frame-color>#94d628</frame-color>
@@ -1177,7 +1029,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1185,8 +1036,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Schottky_diode 241/0@1</source>
+  <name>Schottky_diode</name>
+  <source>241/0</source>
  </properties>
  <properties>
   <frame-color>#5660ce</frame-color>
@@ -1194,7 +1045,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1202,8 +1052,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>ZENER 178/0@1</source>
+  <name>ZENER</name>
+  <source>178/0</source>
  </properties>
  <properties>
   <frame-color>#4a0c51</frame-color>
@@ -1211,7 +1061,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1219,8 +1068,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>RES_MK 110/5@1</source>
+  <name>RES_MK</name>
+  <source>110/5</source>
  </properties>
  <properties>
   <frame-color>#84fd79</frame-color>
@@ -1228,7 +1077,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1236,8 +1084,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>OPC_drc 124/5@1</source>
+  <name>OPC_drc</name>
+  <source>124/5</source>
  </properties>
  <properties>
   <frame-color>#49ee98</frame-color>
@@ -1245,7 +1093,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1253,8 +1100,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>NDMY 111/5@1</source>
+  <name>NDMY</name>
+  <source>111/5</source>
  </properties>
  <properties>
   <frame-color>#0c7e5b</frame-color>
@@ -1262,7 +1109,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1270,8 +1116,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>PMNDMY 152/5@1</source>
+  <name>PMNDMY</name>
+  <source>152/5</source>
  </properties>
  <properties>
   <frame-color>#49b403</frame-color>
@@ -1279,7 +1125,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1287,8 +1132,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>V5_XTOR 112/1@1</source>
+  <name>V5_XTOR</name>
+  <source>112/1</source>
  </properties>
  <properties>
   <frame-color>#2522b7</frame-color>
@@ -1296,7 +1141,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1304,8 +1148,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>CAP_MK 117/5@1</source>
+  <name>CAP_MK</name>
+  <source>117/5</source>
  </properties>
  <properties>
   <frame-color>#0c5e62</frame-color>
@@ -1313,7 +1157,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1321,8 +1164,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MOS_CAP_MK 166/5@1</source>
+  <name>MOS_CAP_MK</name>
+  <source>166/5</source>
  </properties>
  <properties>
   <frame-color>#99ac7e</frame-color>
@@ -1330,7 +1173,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1338,8 +1180,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>IND_MK 151/5@1</source>
+  <name>IND_MK</name>
+  <source>151/5</source>
  </properties>
  <properties>
   <frame-color>#9f0f89</frame-color>
@@ -1347,7 +1189,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1355,8 +1196,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>DIODE_MK 115/5@1</source>
+  <name>DIODE_MK</name>
+  <source>115/5</source>
  </properties>
  <properties>
   <frame-color>#04507b</frame-color>
@@ -1364,7 +1205,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1372,8 +1212,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>DRC_BJT 127/5@1</source>
+  <name>DRC_BJT</name>
+  <source>127/5</source>
  </properties>
  <properties>
   <frame-color>#0e7575</frame-color>
@@ -1381,7 +1221,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1389,8 +1228,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LVS_BJT 118/5@1</source>
+  <name>LVS_BJT</name>
+  <source>118/5</source>
  </properties>
  <properties>
   <frame-color>#f6b1ef</frame-color>
@@ -1398,7 +1237,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1406,8 +1244,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MIM_L_MK 117/10@1</source>
+  <name>MIM_L_MK</name>
+  <source>117/10</source>
  </properties>
  <properties>
   <frame-color>#10c9d8</frame-color>
@@ -1415,7 +1253,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1423,8 +1260,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Latchup_MK 137/5@1</source>
+  <name>Latchup_MK</name>
+  <source>137/5</source>
  </properties>
  <properties>
   <frame-color>#79d94d</frame-color>
@@ -1432,7 +1269,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1440,8 +1276,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>GUARD_RING_MK 167/5@1</source>
+  <name>GUARD_RING_MK</name>
+  <source>167/5</source>
  </properties>
  <properties>
   <frame-color>#2aa0fb</frame-color>
@@ -1449,7 +1285,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1457,8 +1292,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>OTP_MK 173/5@1</source>
+  <name>OTP_MK </name>
+  <source>173/5</source>
  </properties>
  <properties>
   <frame-color>#7b407b</frame-color>
@@ -1466,7 +1301,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1474,8 +1308,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MTPMARK 122/5@1</source>
+  <name>MTPMARK</name>
+  <source>122/5</source>
  </properties>
  <properties>
   <frame-color>#f894c4</frame-color>
@@ -1483,7 +1317,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1491,8 +1324,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>NEO_EE_MK 88/17@1</source>
+  <name>NEO_EE_MK</name>
+  <source>88/17</source>
  </properties>
  <properties>
   <frame-color>#d69c01</frame-color>
@@ -1500,7 +1333,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1508,8 +1340,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>SramCore 108/5@1</source>
+  <name>SramCore</name>
+  <source>108/5</source>
  </properties>
  <properties>
   <frame-color>#c80a86</frame-color>
@@ -1517,7 +1349,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1525,8 +1356,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LVS_RF 100/5@1</source>
+  <name>LVS_RF</name>
+  <source>100/5</source>
  </properties>
  <properties>
   <frame-color>#fa898a</frame-color>
@@ -1534,7 +1365,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1542,8 +1372,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LVS_Drain 100/7@1</source>
+  <name>LVS_Drain</name>
+  <source>100/7</source>
  </properties>
  <properties>
   <frame-color>#5a305a</frame-color>
@@ -1551,7 +1381,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1559,8 +1388,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>IND_MK 151/5@1</source>
+  <name>IND_MK</name>
+  <source>151/5</source>
  </properties>
  <properties>
   <frame-color>#c2bf6d</frame-color>
@@ -1568,7 +1397,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1576,8 +1404,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>HVPOLYRS 123/5@1</source>
+  <name>HVPOLYRS</name>
+  <source>123/5</source>
  </properties>
  <properties>
   <frame-color>#9f3b8a</frame-color>
@@ -1585,7 +1413,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1593,8 +1420,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LVS_IO 119/5@1</source>
+  <name>LVS_IO</name>
+  <source>119/5</source>
  </properties>
  <properties>
   <frame-color>#5aac8a</frame-color>
@@ -1602,7 +1429,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1610,8 +1436,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>PROBE_MK 13/17@1</source>
+  <name>PROBE_MK</name>
+  <source>13/17</source>
  </properties>
  <properties>
   <frame-color>#5de533</frame-color>
@@ -1619,7 +1445,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1627,8 +1452,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>ESD_MK 24/5@1</source>
+  <name>ESD_MK</name>
+  <source>24/5</source>
  </properties>
  <properties>
   <frame-color>#b654a3</frame-color>
@@ -1636,7 +1461,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1644,8 +1468,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LVS_Source 100/8@1</source>
+  <name>LVS_Source</name>
+  <source>100/8</source>
  </properties>
  <properties>
   <frame-color>#9beaaf</frame-color>
@@ -1653,7 +1477,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1661,8 +1484,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>WELL_DIODE_MK 153/51@1</source>
+  <name>WELL_DIODE_MK</name>
+  <source>153/51</source>
  </properties>
  <properties>
   <frame-color>#b0eb32</frame-color>
@@ -1670,7 +1493,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1678,8 +1500,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>LDMOS_XTOR 226/0@1</source>
+  <name>LDMOS_XTOR</name>
+  <source>226/0</source>
  </properties>
  <properties>
   <frame-color>#2507df</frame-color>
@@ -1687,7 +1509,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1695,8 +1516,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>PLFUSE 125/5@1</source>
+  <name>PLFUSE</name>
+  <source>125/5</source>
  </properties>
  <properties>
   <frame-color>#7791b3</frame-color>
@@ -1704,7 +1525,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1712,8 +1532,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>EFUSE_MK 80/5@1</source>
+  <name>EFUSE_MK</name>
+  <source>80/5</source>
  </properties>
  <properties>
   <frame-color>#ac9801</frame-color>
@@ -1721,7 +1541,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1729,8 +1548,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MCELL_FEOL_MK 11/17@1</source>
+  <name>MCELL_FEOL_MK</name>
+  <source>11/17</source>
  </properties>
  <properties>
   <frame-color>#ae438e</frame-color>
@@ -1738,7 +1557,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1746,8 +1564,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>YMTP_MK 86/17@1</source>
+  <name>YMTP_MK</name>
+  <source>86/17</source>
  </properties>
  <properties>
   <frame-color>#5779b7</frame-color>
@@ -1755,7 +1573,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1763,8 +1580,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>DEV_WF_MK 128/17@1</source>
+  <name>DEV_WF_MK</name>
+  <source>128/17</source>
  </properties>
  <properties>
   <frame-color>#8e3415</frame-color>
@@ -1772,7 +1589,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1780,8 +1596,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal1_BLK 34/5@1</source>
+  <name>Metal1_BLK</name>
+  <source>34/5</source>
  </properties>
  <properties>
   <frame-color>#47649f</frame-color>
@@ -1789,7 +1605,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1797,8 +1612,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal2_BLK 36/5@1</source>
+  <name>Metal2_BLK</name>
+  <source>36/5</source>
  </properties>
  <properties>
   <frame-color>#3bf37a</frame-color>
@@ -1806,7 +1621,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1814,8 +1628,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal3_BLK 42/5@1</source>
+  <name>Metal3_BLK</name>
+  <source>42/5</source>
  </properties>
  <properties>
   <frame-color>#678619</frame-color>
@@ -1823,7 +1637,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1831,8 +1644,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal4_BLK 46/5@1</source>
+  <name>Metal4_BLK</name>
+  <source>46/5</source>
  </properties>
  <properties>
   <frame-color>#44fa82</frame-color>
@@ -1840,7 +1653,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1848,8 +1660,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal5_BLK 81/5@1</source>
+  <name>Metal5_BLK</name>
+  <source>81/5</source>
  </properties>
  <properties>
   <frame-color>#614b6a</frame-color>
@@ -1857,7 +1669,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1865,8 +1676,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MetalT_BLK 53/5@1</source>
+  <name>MetalT_BLK</name>
+  <source>53/5</source>
  </properties>
  <properties>
   <frame-color>#d9f817</frame-color>
@@ -1874,7 +1685,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1882,8 +1692,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>PR_bndry 0/0@1</source>
+  <name>PR_bndry</name>
+  <source>0/0</source>
  </properties>
  <properties>
   <frame-color>#d9f817</frame-color>
@@ -1891,7 +1701,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1899,8 +1708,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>VTEXT 63/63@1</source>
+  <name>VTEXT</name>
+  <source>63/63</source>
  </properties>
  <properties>
   <frame-color>#0bdfb7</frame-color>
@@ -1908,7 +1717,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1916,8 +1724,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>MDIODE 116/5@1</source>
+  <name>MDIODE</name>
+  <source>116/5</source>
  </properties>
  <properties>
   <frame-color>#658af3</frame-color>
@@ -1925,7 +1733,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1933,8 +1740,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal1_Res 110/11@1</source>
+  <name>Metal1_Res</name>
+  <source>110/11</source>
  </properties>
  <properties>
   <frame-color>#e9465c</frame-color>
@@ -1942,7 +1749,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1950,8 +1756,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal2_Res 110/12@1</source>
+  <name>Metal2_Res</name>
+  <source>110/12</source>
  </properties>
  <properties>
   <frame-color>#ba3263</frame-color>
@@ -1959,7 +1765,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1967,8 +1772,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal3_Res 110/13@1</source>
+  <name>Metal3_Res</name>
+  <source>110/13</source>
  </properties>
  <properties>
   <frame-color>#ddeef3</frame-color>
@@ -1976,7 +1781,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -1984,8 +1788,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal4_Res 110/14@1</source>
+  <name>Metal4_Res</name>
+  <source>110/14</source>
  </properties>
  <properties>
   <frame-color>#004676</frame-color>
@@ -1993,7 +1797,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -2001,8 +1804,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal5_Res 110/15@1</source>
+  <name>Metal5_Res</name>
+  <source>110/15</source>
  </properties>
  <properties>
   <frame-color>#e4b00d</frame-color>
@@ -2010,7 +1813,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I5</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -2018,8 +1820,8 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Metal6_Res 110/16@1</source>
+  <name>Metal6_Res</name>
+  <source>110/16</source>
  </properties>
  <properties>
   <frame-color>#edeb06</frame-color>
@@ -2027,7 +1829,6 @@ limitations under the License.
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
   <dither-pattern>I9</dither-pattern>
-  <line-style/>
   <valid>true</valid>
   <visible>true</visible>
   <transparent>false</transparent>
@@ -2035,8 +1836,7 @@ limitations under the License.
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name/>
-  <source>Border 63/0@1</source>
+  <name>Border</name>
+  <source>63/0</source>
  </properties>
- <name/>
 </layer-properties>


### PR DESCRIPTION
I've been asked by @martinjankoehler to help jku's pin tool to support the gf180 pdk, resulting in https://github.com/iic-jku/klayout-pin-tool/pull/5
It turns out that it is currently not possible to do cleanly, because the pdk does not name properly its layers.

The problem is that we have the following structure:
For `gf180mcu.lyp`:
```
 <properties>
  [...]
  <name/>
  <source>Metal1 34/0@1</source>
 </properties>
```

Whereas, for `ihp-sg13g2.lyp`, it is properly done:
```
  <properties>
    [...]
    <name>Metal1.drawing</name>
    <source>8/0</source>
  </properties>
```

The present commit populates the name tag properly, removes the name from the source tag, removes empty tag line-style, and removes undocumented layers:
* 1/222
* 5/222
* 12/222
* 14/222
* 15/222

These layers are also absent from the magic tech files.