### PR TITLE
Fix incorrect sky130 model reference in gf180mcuD xschem transistor symbols

### DIFF
--- a/cells/xschem/symbols/nfet_03v3.sym
+++ b/cells/xschem/symbols/nfet_03v3.sym
@@ -61,7 +61,7 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}

--- a/cells/xschem/symbols/nfet_03v3_dss.sym
+++ b/cells/xschem/symbols/nfet_03v3_dss.sym
@@ -63,8 +63,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet_05v0.sym
+++ b/cells/xschem/symbols/nfet_05v0.sym
@@ -60,8 +60,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet_06v0.sym
+++ b/cells/xschem/symbols/nfet_06v0.sym
@@ -60,8 +60,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet_06v0_dss.sym
+++ b/cells/xschem/symbols/nfet_06v0_dss.sym
@@ -63,8 +63,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet_06v0_nvt.sym
+++ b/cells/xschem/symbols/nfet_06v0_nvt.sym
@@ -60,8 +60,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet_10v0_asym.sym
+++ b/cells/xschem/symbols/nfet_10v0_asym.sym
@@ -60,9 +60,9 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}
 T {10V} -16.25 19.375 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/pfet_03v3.sym
+++ b/cells/xschem/symbols/pfet_03v3.sym
@@ -61,8 +61,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_03v3_dss.sym
+++ b/cells/xschem/symbols/pfet_03v3_dss.sym
@@ -64,8 +64,8 @@ T {G} -10 -10 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_05v0.sym
+++ b/cells/xschem/symbols/pfet_05v0.sym
@@ -61,8 +61,8 @@ T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_06v0.sym
+++ b/cells/xschem/symbols/pfet_06v0.sym
@@ -61,8 +61,8 @@ T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_06v0_dss.sym
+++ b/cells/xschem/symbols/pfet_06v0_dss.sym
@@ -64,8 +64,8 @@ T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_10v0_asym.sym
+++ b/cells/xschem/symbols/pfet_10v0_asym.sym
@@ -61,9 +61,9 @@ T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
 T {@model} 30 -8.75 2 1 0.2 0.2 {}
 T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
 T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
-T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
 hide=true}
-T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
 hide=true}
 T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}
 T {10V} -18.75 16.875 0 0 0.2 0.2 { layer=4}


### PR DESCRIPTION
The OP annotation tcleval expressions incorrectly use msky130_fd_pr__@model instead of m0 (the actual internal MOSFET element name in gf180mcu subcircuits).

Patch taken from IIC-OSIC-TOOLS.