### PR TITLE
klayout lvs: remove unneeded options

### DIFF
--- a/rules/klayout/macros/gf180mcu_lvs.lylvs
+++ b/rules/klayout/macros/gf180mcu_lvs.lylvs
@@ -89,11 +89,9 @@ unless options["top_cell_name"] == ""
   $topcell = options["top_cell_name"]
 end
 
-$spice_net_names = options["spice_net"]
+$spice_net_names = "true"
 
-$spice_comments = options["spice_comment"]
-
-$scale = options["scale"]
+$spice_comments = "true"
 
 $verbose = options["verbose"]
 

--- a/rules/klayout/macros/gf180mcu_options.lym
+++ b/rules/klayout/macros/gf180mcu_options.lym
@@ -123,14 +123,10 @@ lvs_builder = OptionMenuBuilder.new(
   "submenu.lvs_menu"
 )
 
-lvs_builder.add_string("sub_name", "Substrate name", "Substrate name", "Please enter substrate name", menu_id: "SUB_name")
 lvs_builder.add_selection("run_mode", "Run mode", %w[tiling deep flat], "Run mode", "Select run mode:", 1)
 lvs_builder.add_selection("variant", "variant options", %w[A B C D], "Variant options", "Select variant option:", 1)
 lvs_builder.add_string("netlist", "Netlist Path", "Netlist Path", "Please enter Netlist Path", menu_id: "Netlist_path")
 lvs_builder.add_string("top_cell_name", "Top_cell name", "Top cell name", "Please enter Top_cell name. Empty means run on current cell.", menu_id: "TOP_cell_name")
-lvs_builder.add_checkbox("spice_net", "SPICE net name", lvs_initial["spice_net"], menu_id: "SPICE_net_name")
-lvs_builder.add_checkbox("spice_comment", "SPICE comments", lvs_initial["spice_comment"], menu_id: "SPICE_comments")
-lvs_builder.add_checkbox("scale", "Scaling x10^6", lvs_initial["scale"])
 lvs_builder.add_checkbox("verbose", "Verbose mode", lvs_initial["verbose"])
 lvs_builder.add_checkbox("simplify", "Simplify", lvs_initial["simplify"])
 lvs_builder.add_checkbox("net_only", "Netlist only", lvs_initial["net_only"])

--- a/rules/klayout/macros/lvs_defaults.yml
+++ b/rules/klayout/macros/lvs_defaults.yml
@@ -1,11 +1,8 @@
 ---
-sub_name: gf180mcu_gnd
 run_mode: deep
 variant: D
 netlist: ''
-spice_net: true
 top_cell_name: ''
-spice_comment: false
 scale: false
 verbose: true
 simplify: true


### PR DESCRIPTION
Do not expose scale, substrate naming, spice_net_name and spice_comment options, as they are not useful and take precious space. spice_net_name and spice_comment are still accessible via command line.

Companion `_pv` PR: https://github.com/fossi-foundation/globalfoundries-pdk-libs-gf180mcu_fd_pv/pull/19