### PR TITLE
feat: name DRC and LVS group

### DIFF
--- a/rules/klayout/macros/gf180mcu_drc.lydrc
+++ b/rules/klayout/macros/gf180mcu_drc.lydrc
@@ -11,7 +11,7 @@
  <priority>0</priority>
  <shortcut/>
  <show-in-menu>true</show-in-menu>
- <group-name/>
+ <group-name>DRC and LVS</group-name>
  <menu-path>submenu&gt;end("gf180mcu PDK").end</menu-path>
  <interpreter>dsl</interpreter>
  <dsl-interpreter-name>drc-dsl-xml</dsl-interpreter-name>

--- a/rules/klayout/macros/gf180mcu_lvs.lylvs
+++ b/rules/klayout/macros/gf180mcu_lvs.lylvs
@@ -11,7 +11,7 @@
  <priority>0</priority>
  <shortcut/>
  <show-in-menu>true</show-in-menu>
- <group-name/>
+ <group-name>DRC and LVS</group-name>
  <menu-path>submenu&gt;end("gf180mcu PDK").end</menu-path>
  <interpreter>dsl</interpreter>
  <dsl-interpreter-name>lvs-dsl-xml</dsl-interpreter-name>


### PR DESCRIPTION
This PR simply names the DRC and LVS group so that when adding another group they are still separate.