### PR TITLE
Add xschem symbols variants with body as attribute for nfet/pfet

### DIFF
--- a/cells/xschem/symbols/nfet3_03v3.sym
+++ b/cells/xschem/symbols/nfet3_03v3.sym
@@ -1,0 +1,67 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=nmos
+format="@spiceprefix@name @pinlist @body @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @body @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.28u
+W=0.22u
+body=GND
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=nfet_03v3
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 -20 0 2.5 0 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 2.5 -15 2.5 15 {}
+L 4 7.5 -17.5 20 -17.5 {}
+L 4 7.5 17.5 15 17.5 {}
+L 4 7.5 -10 12.5 -10 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 27.5 22.5 32.5 {name=S dir=inout}
+P 4 4 15 15 20 17.5 15 20 15 15 {fill=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}
+T {S} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {D} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {G} -10 -10 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -17.5 2 1 0.2 0.2 {}
+T {@body} 12.5 -3.75 2 1 0.2 0.2 { layer=1}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+hide=true}

--- a/cells/xschem/symbols/nfet3_05v0.sym
+++ b/cells/xschem/symbols/nfet3_05v0.sym
@@ -1,0 +1,67 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=nmos
+format="@spiceprefix@name @pinlist @body @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @body @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.60u
+W=0.30u
+body=GND
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=nfet_05v0
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 -20 0 -2.5 0 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 -2.5 -15 -2.5 15 {}
+L 4 7.5 -17.5 20 -17.5 {}
+L 4 7.5 17.5 15 17.5 {}
+L 4 7.5 -10 12.5 -10 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 27.5 22.5 32.5 {name=S dir=inout}
+P 4 4 15 15 20 17.5 15 20 15 15 {fill=true}
+T {S} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {D} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {G} -10 -10 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -17.5 2 1 0.2 0.2 {}
+T {@body} 12.5 -3.75 2 1 0.2 0.2 { layer=1}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -50 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -40 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet3_06v0.sym
+++ b/cells/xschem/symbols/nfet3_06v0.sym
@@ -1,0 +1,67 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=nmos
+format="@spiceprefix@name @pinlist @body @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @body @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.70u
+W=0.30u
+body=GND
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=nfet_06v0
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 -20 0 -2.5 0 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 -2.5 -15 -2.5 15 {}
+L 4 7.5 -17.5 20 -17.5 {}
+L 4 7.5 17.5 15 17.5 {}
+L 4 7.5 -10 12.5 -10 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 27.5 22.5 32.5 {name=S dir=inout}
+P 4 4 15 15 20 17.5 15 20 15 15 {fill=true}
+T {S} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {D} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {G} -10 -10 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -17.5 2 1 0.2 0.2 {}
+T {@body} 12.5 -3.75 2 1 0.2 0.2 { layer=1}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -50 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -40 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet3_03v3.sym
+++ b/cells/xschem/symbols/pfet3_03v3.sym
@@ -1,0 +1,68 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=pmos
+format="@spiceprefix@name @pinlist @body @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @body @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.28u
+W=0.22u
+body=VDD
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=pfet_03v3
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 2.5 -15 2.5 15 {}
+L 4 7.5 17.5 20 17.5 {}
+L 4 12.5 -17.5 20 -17.5 {}
+L 4 -20 0 -7.5 0 {}
+L 4 7.5 -10 12.5 -10 {}
+B 5 17.5 27.5 22.5 32.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 -32.5 22.5 -27.5 {name=S dir=inout}
+A 4 -2.5 0 5 180 360 {}
+P 4 4 12.5 -20 7.5 -17.5 12.5 -15 12.5 -20 {fill=true}
+T {D} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {S} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {G} -10 -10 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -17.5 2 1 0.2 0.2 {}
+T {@body} 12.5 -3.75 2 1 0.2 0.2 { layer=1}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -50 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -40 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet3_05v0.sym
+++ b/cells/xschem/symbols/pfet3_05v0.sym
@@ -1,0 +1,68 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=pmos
+format="@spiceprefix@name @pinlist @body @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @body @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.50u
+W=0.30u
+body=VDD
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=pfet_05v0
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 -2.5 -15 -2.5 15 {}
+L 4 7.5 17.5 20 17.5 {}
+L 4 12.5 -17.5 20 -17.5 {}
+L 4 -20 0 -12.5 0 {}
+L 4 7.5 -10 12.5 -10 {}
+B 5 17.5 27.5 22.5 32.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 -32.5 22.5 -27.5 {name=S dir=inout}
+A 4 -7.5 0 5 180 360 {}
+P 4 4 12.5 -20 7.5 -17.5 12.5 -15 12.5 -20 {fill=true}
+T {D} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {S} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -17.5 2 1 0.2 0.2 {}
+T {@body} 12.5 -3.75 2 1 0.2 0.2 { layer=1}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -50 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -40 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet3_06v0.sym
+++ b/cells/xschem/symbols/pfet3_06v0.sym
@@ -1,0 +1,68 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=pmos
+format="@spiceprefix@name @pinlist @body @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @body @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.55u
+W=0.30u
+body=VDD
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=pfet_06v0
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 -2.5 -15 -2.5 15 {}
+L 4 7.5 17.5 20 17.5 {}
+L 4 12.5 -17.5 20 -17.5 {}
+L 4 -20 0 -12.5 0 {}
+L 4 7.5 -10 12.5 -10 {}
+B 5 17.5 27.5 22.5 32.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 -32.5 22.5 -27.5 {name=S dir=inout}
+A 4 -7.5 0 5 180 360 {}
+P 4 4 12.5 -20 7.5 -17.5 12.5 -15 12.5 -20 {fill=true}
+T {D} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {S} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -17.5 2 1 0.2 0.2 {}
+T {@body} 12.5 -3.75 2 1 0.2 0.2 { layer=1}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.m0\\[gm]\}]] )} 32.5 -50 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.m0\\[id])\}]] )} 32.5 -40 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}


### PR DESCRIPTION
This is something available for the sky130 xschem library and that makes schematic a whole lot clearer a lot of the time IMHO ...