### PR TITLE
cells/xschem: Fix cut&paste error in npolyf symbols

### DIFF
--- a/cells/xschem/symbols/npolyf_s.sym
+++ b/cells/xschem/symbols/npolyf_s.sym
@@ -21,7 +21,7 @@ format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
 template="name=R1
 W=1e-6
 L=1e-6
-model=nplus_s
+model=npolyf_s
 spiceprefix=X
 m=1"
 }

--- a/cells/xschem/symbols/npolyf_u.sym
+++ b/cells/xschem/symbols/npolyf_u.sym
@@ -21,7 +21,7 @@ format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
 template="name=R1
 W=1e-6
 L=1e-6
-model=nplus_u
+model=npolyf_u
 spiceprefix=X
 m=1"
 }


### PR DESCRIPTION
They reference the wrong model ...
