### PR TITLE
gf180mcu_options.lym: fix gui checkboxes

### DIFF
--- a/rules/klayout/macros/gf180mcu_options.lym
+++ b/rules/klayout/macros/gf180mcu_options.lym
@@ -70,7 +70,7 @@ class OptionMenuBuilder
     action.checked = initial_checked
     action.on_triggered do
       opts = @get_opts.call
-      opts[key] = action.checked?
+      opts[key] = action.is_checked?
       @save_opts.call(opts)
     end
     @mw.menu.insert_item("#{@menu_path}.end", menu_id || key, action)


### PR DESCRIPTION
Fixes a regression introduced with the reworked klayout DRC, where selecting (or not) option would have no effect and cause the following warning:
```
Warning: NoMethodError: undefined method 'checked?' for an instance of RBA::Action
 XXX/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_options.lym:56:in 'block in OptionMenuBuilder#add_checkbox'
