### PR TITLE
fix: avoid dummy shapes during fill

### DIFF
--- a/cells/klayout/scripts/fill_comp.rb
+++ b/cells/klayout/scripts/fill_comp.rb
@@ -49,6 +49,7 @@ tp.tile_size(tile_size, tile_size)
 tp.tile_border(30, 30)
 
 tp.input("COMP", $ly, $top_cell.cell_index, COMP)
+tp.input("COMP_Dummy", $ly, $top_cell.cell_index, COMP_Dummy)
 tp.input("Poly2", $ly, $top_cell.cell_index, Poly2)
 tp.input("NDMY", $ly, $top_cell.cell_index, NDMY)
 
@@ -61,14 +62,14 @@ tp.input("RES_MK", $ly, $top_cell.cell_index, RES_MK)
 tp.input("Pad", $ly, $top_cell.cell_index, Pad)
 tp.input("IND_MK", $ly, $top_cell.cell_index, IND_MK)
 
-tp.var("line_space", line_space / $ly.dbu)
-
 # DPF.1
 # Make sure to exclude some space at the tile border
 # to ensure there will be no dummy poly2 without a
 # dummy comp
 tp.var("Poly2_extension", 0.3 / $ly.dbu)
 
+# DCF.2a
+tp.var("space_to_COMP_Dummy", line_space / $ly.dbu)
 # DCF.4
 tp.var("space_to_COMP", 3.5 / $ly.dbu)
 # DCF.5
@@ -107,6 +108,7 @@ tp.output("to_fill", TilingOperator::new($ly, $fill_cell_comp, fill_cell.cell_in
 tp.queue("
 
 # DCF.1a - use octagon_limit for sizing, do multiple steps for better performance
+# TODO: do we actually need to keep 20um area empty? 'must be filled'
 var COMP_20um_spacing = COMP.sized(um10, 0, mode=2).sized(0, um10, mode=2).sized(-um10, 0, mode=2).sized(0, -um10, mode=2);
 
 # DCF.6abcd
@@ -122,6 +124,7 @@ var scribe_line_ring = _frame - _frame.sized(-space_to_scribe_line);
 var fill_region = _tile & _frame
                   - _tile.not(_tile.sized(-Poly2_extension))
                   - COMP_20um_spacing.sized(space_to_COMP)
+                  - COMP_Dummy.sized(space_to_COMP_Dummy)
                   - Poly2.sized(space_to_Poly2)
                   - Nwell_ring
                   - DNWELL_ring

--- a/cells/klayout/scripts/fill_metal.rb
+++ b/cells/klayout/scripts/fill_metal.rb
@@ -56,6 +56,9 @@ line_spaces = {
   "Metal2" => 1.2,
   "Metal3" => 1.2,
   "Metal4" => 1.2,
+  # TODO differentiate between normal
+  # and thick top metal (3um).
+  # For now, assume worst case.
   "Metal5" => 2
 }
 
@@ -131,6 +134,7 @@ for metal in do_layers
   tp.tile_border(30, 30)
   
   tp.input("Metal", $ly, $top_cell.cell_index, metal_layers[metal])
+  tp.input("Metal_Dummy", $ly, $top_cell.cell_index, fill_layers[metal])
   tp.input("subsequent_metal", $ly, $top_cell.cell_index, subsequent_metals[metal])
   tp.input("previous_metal", $ly, $top_cell.cell_index, previous_metals[metal])
   tp.input("FuseTop", $ly, $top_cell.cell_index, FuseTop)
@@ -146,6 +150,9 @@ for metal in do_layers
   tp.input("Metal3", $ly, $top_cell.cell_index, Metal3)
   tp.input("Metal4", $ly, $top_cell.cell_index, Metal4)
   tp.input("Metal5", $ly, $top_cell.cell_index, Metal5)
+
+  # DM.2a, DM.2c
+  tp.var("space_to_Metal_Dummy", line_spaces[metal] / $ly.dbu)
 
   # DM.3
   tp.var("space_to_Metal", 2.0 / $ly.dbu)
@@ -178,6 +185,7 @@ var scribe_line_ring = _frame - _frame.sized(-space_to_scribe_line);
 
 var fill_region = _tile & _frame
                   - Metal.sized(space_to_Metal)
+                  - Metal_Dummy.sized(space_to_Metal_Dummy)
                   - FuseTop.sized(space_to_FuseTop)
                   - POLYFUSE.sized(space_to_POLYFUSE)
                   - FUSEWINDOW_D.sized(space_to_FUSEWINDOW_D)
@@ -194,6 +202,7 @@ var scribe_line_ring = _frame - _frame.sized(-space_to_scribe_line);
 
 var fill_region = _tile & _frame
                   - Metal.sized(space_to_Metal)
+                  - Metal_Dummy.sized(space_to_Metal_Dummy)
                   - previous_metal.sized(space_to_previous_Metal)
                   - subsequent_metal.sized(space_to_subsequent_Metal)
                   - FuseTop.sized(space_to_FuseTop)

--- a/cells/klayout/scripts/fill_poly2.rb
+++ b/cells/klayout/scripts/fill_poly2.rb
@@ -50,6 +50,7 @@ tp.tile_border(30, 30)
 
 tp.input("COMP", $ly, $top_cell.cell_index, COMP)
 tp.input("Poly2", $ly, $top_cell.cell_index, Poly2)
+tp.input("Poly2_Dummy", $ly, $top_cell.cell_index, Poly2_Dummy)
 tp.input("NDMY", $ly, $top_cell.cell_index, NDMY)
 tp.input("PMNDMY", $ly, $top_cell.cell_index, PMNDMY)
 tp.input("MTPMK", $ly, $top_cell.cell_index, MTPMK)
@@ -68,6 +69,8 @@ tp.input("Metal2", $ly, $top_cell.cell_index, Metal2)
 
 tp.var("line_space", line_space / $ly.dbu)
 
+# DPF.2a
+tp.var("space_to_Poly2_Dummy", line_space / $ly.dbu)
 # DPF.4
 tp.var("space_to_COMP", 3.2 / $ly.dbu)
 # DPF.5
@@ -136,6 +139,7 @@ var scribe_line_ring = _frame - _frame.sized(-space_to_scribe_line);
 var fill_region = _tile & _frame
                   - COMP_20um_spacing.sized(space_to_COMP)
                   - Poly2.sized(space_to_Poly2)
+                  - Poly2_Dummy.sized(space_to_Poly2_Dummy)
                   - Nwell_ring
                   - DNWELL_ring
                   - LVPWELL_ring


### PR DESCRIPTION
Ignore existing dummy shapes during filler generation. This can happen if some macros are already pre-filled.