### PR TITLE
fix: filler generation: DPF.1a is only used for DRC

### DIFF
--- a/cells/klayout/scripts/fill_comp.rb
+++ b/cells/klayout/scripts/fill_comp.rb
@@ -107,10 +107,6 @@ tp.output("to_fill", TilingOperator::new($ly, $fill_cell_comp, fill_cell.cell_in
 # (see https://www.klayout.de/doc-qt4/about/expressions.html)
 tp.queue("
 
-# DCF.1a - use octagon_limit for sizing, do multiple steps for better performance
-# TODO: do we actually need to keep 20um area empty? 'must be filled'
-var COMP_20um_spacing = COMP.sized(um10, 0, mode=2).sized(0, um10, mode=2).sized(-um10, 0, mode=2).sized(0, -um10, mode=2);
-
 # DCF.6abcd
 var Nwell_ring    = Nwell.sized(space_to_Nwell)       - Nwell.sized(-space_to_Nwell);
 var DNWELL_ring   = DNWELL.sized(space_to_DNWELL)     - DNWELL.sized(-space_to_DNWELL);
@@ -123,7 +119,7 @@ var scribe_line_ring = _frame - _frame.sized(-space_to_scribe_line);
 
 var fill_region = _tile & _frame
                   - _tile.not(_tile.sized(-Poly2_extension))
-                  - COMP_20um_spacing.sized(space_to_COMP)
+                  - COMP.sized(space_to_COMP)
                   - COMP_Dummy.sized(space_to_COMP_Dummy)
                   - Poly2.sized(space_to_Poly2)
                   - Nwell_ring

--- a/cells/klayout/scripts/fill_poly2.rb
+++ b/cells/klayout/scripts/fill_poly2.rb
@@ -123,9 +123,6 @@ tp.output("to_fill", TilingOperator::new($ly, $fill_cell_poly2, fill_cell.cell_i
 # (see https://www.klayout.de/doc-qt4/about/expressions.html)
 tp.queue("
 
-# DPF.1a - use octagon_limit for sizing, do multiple steps for better performance
-var COMP_20um_spacing = COMP.sized(um10, 0, mode=2).sized(0, um10, mode=2).sized(-um10, 0, mode=2).sized(0, -um10, mode=2);
-
 # DPF.6abcd
 var Nwell_ring    = Nwell.sized(space_to_Nwell)       - Nwell.sized(-space_to_Nwell);
 var DNWELL_ring   = DNWELL.sized(space_to_DNWELL)     - DNWELL.sized(-space_to_DNWELL);
@@ -137,7 +134,7 @@ var Dualgate_ring = Dualgate.sized(space_to_Dualgate) - Dualgate.sized(-space_to
 var scribe_line_ring = _frame - _frame.sized(-space_to_scribe_line);
 
 var fill_region = _tile & _frame
-                  - COMP_20um_spacing.sized(space_to_COMP)
+                  - COMP.sized(space_to_COMP)
                   - Poly2.sized(space_to_Poly2)
                   - Poly2_Dummy.sized(space_to_Poly2_Dummy)
                   - Nwell_ring


### PR DESCRIPTION
I misunderstood the rule as I thought it would apply to filler generation with a keep out zone for dummy comp.
This removes the restriction. DCF.1a is now checked in the DRC rules.